### PR TITLE
WIP: Add Unit Tests

### DIFF
--- a/Brewlet.xcodeproj/project.pbxproj
+++ b/Brewlet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		070E0CA82471AC81001B38ED /* BrewletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 070E0CA72471AC81001B38ED /* BrewletTests.swift */; };
 		BB95C6F024030F1B00995E0A /* PreferencesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB95C6EE24030F1B00995E0A /* PreferencesController.swift */; };
 		BB95C6F124030F1B00995E0A /* PreferencesController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BB95C6EF24030F1B00995E0A /* PreferencesController.xib */; };
 		BBC6CAB123EF476B00189F94 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC6CAB023EF476B00189F94 /* AppDelegate.swift */; };
@@ -15,7 +16,20 @@
 		BBED83622400E6B500B4ADA8 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBED83612400E6B500B4ADA8 /* Package.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		070E0CAA2471AC81001B38ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BBC6CAA523EF476B00189F94 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BBC6CAAC23EF476B00189F94;
+			remoteInfo = Brewlet;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		070E0CA52471AC81001B38ED /* BrewletTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BrewletTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		070E0CA72471AC81001B38ED /* BrewletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewletTests.swift; sourceTree = "<group>"; };
+		070E0CA92471AC81001B38ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BB95C6EE24030F1B00995E0A /* PreferencesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesController.swift; sourceTree = "<group>"; };
 		BB95C6EF24030F1B00995E0A /* PreferencesController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PreferencesController.xib; sourceTree = "<group>"; };
 		BBC6CAAD23EF476B00189F94 /* Brewlet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Brewlet.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -28,6 +42,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		070E0CA22471AC81001B38ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BBC6CAAA23EF476B00189F94 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -38,10 +59,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		070E0CA62471AC81001B38ED /* BrewletTests */ = {
+			isa = PBXGroup;
+			children = (
+				070E0CA72471AC81001B38ED /* BrewletTests.swift */,
+				070E0CA92471AC81001B38ED /* Info.plist */,
+			);
+			path = BrewletTests;
+			sourceTree = "<group>";
+		};
 		BBC6CAA423EF476B00189F94 = {
 			isa = PBXGroup;
 			children = (
 				BBC6CAAF23EF476B00189F94 /* Brewlet */,
+				070E0CA62471AC81001B38ED /* BrewletTests */,
 				BBC6CAAE23EF476B00189F94 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -50,6 +81,7 @@
 			isa = PBXGroup;
 			children = (
 				BBC6CAAD23EF476B00189F94 /* Brewlet.app */,
+				070E0CA52471AC81001B38ED /* BrewletTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -72,6 +104,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		070E0CA42471AC81001B38ED /* BrewletTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 070E0CAC2471AC81001B38ED /* Build configuration list for PBXNativeTarget "BrewletTests" */;
+			buildPhases = (
+				070E0CA12471AC81001B38ED /* Sources */,
+				070E0CA22471AC81001B38ED /* Frameworks */,
+				070E0CA32471AC81001B38ED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				070E0CAB2471AC81001B38ED /* PBXTargetDependency */,
+			);
+			name = BrewletTests;
+			productName = BrewletTests;
+			productReference = 070E0CA52471AC81001B38ED /* BrewletTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		BBC6CAAC23EF476B00189F94 /* Brewlet */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BBC6CABB23EF476C00189F94 /* Build configuration list for PBXNativeTarget "Brewlet" */;
@@ -99,6 +149,10 @@
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = zzada;
 				TargetAttributes = {
+					070E0CA42471AC81001B38ED = {
+						CreatedOnToolsVersion = 11.3.1;
+						TestTargetID = BBC6CAAC23EF476B00189F94;
+					};
 					BBC6CAAC23EF476B00189F94 = {
 						CreatedOnToolsVersion = 11.3.1;
 					};
@@ -118,11 +172,19 @@
 			projectRoot = "";
 			targets = (
 				BBC6CAAC23EF476B00189F94 /* Brewlet */,
+				070E0CA42471AC81001B38ED /* BrewletTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		070E0CA32471AC81001B38ED /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BBC6CAAB23EF476B00189F94 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -136,6 +198,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		070E0CA12471AC81001B38ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				070E0CA82471AC81001B38ED /* BrewletTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BBC6CAA923EF476B00189F94 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -147,6 +217,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		070E0CAB2471AC81001B38ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BBC6CAAC23EF476B00189F94 /* Brewlet */;
+			targetProxy = 070E0CAA2471AC81001B38ED /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		BBC6CAB423EF476C00189F94 /* MainMenu.xib */ = {
@@ -160,6 +238,44 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		070E0CAD2471AC81001B38ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = BrewletTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = zkokaja.BrewletTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Brewlet.app/Contents/MacOS/Brewlet";
+			};
+			name = Debug;
+		};
+		070E0CAE2471AC81001B38ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = BrewletTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = zkokaja.BrewletTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Brewlet.app/Contents/MacOS/Brewlet";
+			};
+			name = Release;
+		};
 		BBC6CAB923EF476C00189F94 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -312,6 +428,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		070E0CAC2471AC81001B38ED /* Build configuration list for PBXNativeTarget "BrewletTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				070E0CAD2471AC81001B38ED /* Debug */,
+				070E0CAE2471AC81001B38ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		BBC6CAA823EF476B00189F94 /* Build configuration list for PBXProject "Brewlet" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Brewlet.xcodeproj/xcshareddata/xcschemes/Brewlet.xcscheme
+++ b/Brewlet.xcodeproj/xcshareddata/xcschemes/Brewlet.xcscheme
@@ -17,7 +17,7 @@
                BlueprintIdentifier = "BBC6CAAC23EF476B00189F94"
                BuildableName = "Brewlet.app"
                BlueprintName = "Brewlet"
-               ReferencedContainer = "container:BrewLet.xcodeproj">
+               ReferencedContainer = "container:Brewlet.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "070E0CA42471AC81001B38ED"
+               BuildableName = "BrewletTests.xctest"
+               BlueprintName = "BrewletTests"
+               ReferencedContainer = "container:Brewlet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -47,7 +57,7 @@
             BlueprintIdentifier = "BBC6CAAC23EF476B00189F94"
             BuildableName = "Brewlet.app"
             BlueprintName = "Brewlet"
-            ReferencedContainer = "container:BrewLet.xcodeproj">
+            ReferencedContainer = "container:Brewlet.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -64,7 +74,7 @@
             BlueprintIdentifier = "BBC6CAAC23EF476B00189F94"
             BuildableName = "Brewlet.app"
             BlueprintName = "Brewlet"
-            ReferencedContainer = "container:BrewLet.xcodeproj">
+            ReferencedContainer = "container:Brewlet.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/BrewletTests/BrewletTests.swift
+++ b/BrewletTests/BrewletTests.swift
@@ -20,6 +20,11 @@ class BrewletTests: XCTestCase {
         /// `run_command` where `brew` is not actually invoked
         override func run_command(arguments: [String], fileRedirect: FileHandle? = nil, outputHandler: @escaping (Process, Data) -> Void) {
             NSLog("overridden `run_command`")
+            
+            // Return parameters for closure - currently, no tests require these variables
+            let mockedProcess = Process()
+            let mockedData = Data()
+            outputHandler(mockedProcess, mockedData)
         }
     
     }
@@ -30,7 +35,7 @@ class BrewletTests: XCTestCase {
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         super.setUp()
-        delegate = StatelessAppDelegate() as! AppDelegate
+        delegate = StatelessAppDelegate() as AppDelegate
         
         // Re-initialize defaults instead of triggering `applicationDidFinishLaunching`
         delegate.statusItem.button?.toolTip = "Brewlet"
@@ -74,19 +79,17 @@ class BrewletTests: XCTestCase {
         let v1 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
         XCTAssert(v1 == 3600)
     }
-    
-    // NOTE: this does not work, as the overriden `run_command` will not trigger the
-    // self.userDefaults.set(turnOn, forKey: "shareAnalytics") in `toggle_analytics`
-//    /// Toggle share analytics in preferences - `brew` command is not invoked as  delegate method `run_command` has been overriden
-//    func testShareAnalyticsChanged() {
-//        delegate.shareAnalyticsChanged(newState: .on)
-//        let v0 = delegate.userDefaults.bool(forKey: "shareAnalytics")
-//        XCTAssert(v0 == true)
-//
-//        delegate.shareAnalyticsChanged(newState: .off)
-//        let v1 = delegate.userDefaults.bool(forKey: "shareAnalytics")
-//        XCTAssert(v1 == false)
-//    }
+
+    /// Toggle share analytics in preferences - `brew` command is not invoked as  delegate method `run_command` has been overriden
+    func testShareAnalyticsChanged() {
+        delegate.shareAnalyticsChanged(newState: .on)
+        let v0 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+        XCTAssert(v0 == true)
+
+        delegate.shareAnalyticsChanged(newState: .off)
+        let v1 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+        XCTAssert(v1 == false)
+    }
 
 //    func testToggleAnalytics() {
 //

--- a/BrewletTests/BrewletTests.swift
+++ b/BrewletTests/BrewletTests.swift
@@ -19,6 +19,10 @@ class BrewletTests: XCTestCase {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         super.setUp()
         delegate = NSApplication.shared.delegate as! AppDelegate
+        
+        // Re-initialize defaults instead of triggering `applicationDidFinishLaunching`
+        delegate.statusItem.button?.toolTip = "Brewlet"
+        delegate.statusItem.button?.image = NSImage(named: "BrewletIcon-Black")
     }
 
     override func tearDown() {
@@ -31,6 +35,21 @@ class BrewletTests: XCTestCase {
         let d = Date(timeIntervalSinceReferenceDate: 410220000)
         let f = delegate.formatDate(date: d)
         XCTAssert(f == "Dec 31, 2013 at 5:00 PM")
+    }
+    
+    func testAnimateIconImages() {
+        let animateTimer = delegate.animateIcon()
+        
+        // Status button image name initial value
+        XCTAssert(delegate.statusItem.button?.image?.name() == "BrewletIcon-Black")
+        
+        // Trigger the timer 7 times, the status icon name will increment from "Brewlet-Filled-0" to "Brewlet-Filled-6"
+        for n in 0...6 {
+            animateTimer.fire()
+            let statusImageName = (delegate.statusItem.button?.image?.name())!
+            NSLog("Status Image: \(statusImageName)")
+            XCTAssert("Brewlet-Filled-\(n)" == statusImageName)
+        }
     }
 
 //    func testToggleAnalytics() {

--- a/BrewletTests/BrewletTests.swift
+++ b/BrewletTests/BrewletTests.swift
@@ -11,12 +11,6 @@ import XCTest
 @testable import Brewlet
 
 
-//            // Mock closure data depending on `brew` command arguments when the data variable is leveraged
-//            var data = Data()
-//            switch arguments {
-//            case ["info", "--json", "--installed"]:
-//                data = Data()
-//            }
 
 
 class BrewletTests: XCTestCase {
@@ -50,7 +44,15 @@ class BrewletTests: XCTestCase {
         // Initialize MainMenu.xib
         var objects: NSArray?
         Bundle.main.loadNibNamed("MainMenu", owner: delegate, topLevelObjects: &objects)
-        delegate.statusMenu = objects![0] as? NSMenu
+    
+        // set `statusMenu` of app delegate
+        for object in objects ?? [] {
+            NSLog("Bundle object type: \(type(of: object))")
+            if object is NSMenu {
+                delegate.statusMenu = (object as! NSMenu)
+                break
+            }
+        }
         
         // Re-initialize defaults instead of triggering `applicationDidFinishLaunching`
         delegate.statusItem.button?.toolTip = "Brewlet"
@@ -157,25 +159,25 @@ class BrewletTests: XCTestCase {
         XCTAssert(delegate.userDefaults.bool(forKey: "shareAnalytics") == false)
     }
     
-//    /// TODO: fix fatal error
-//    /// 
-//    /// Info status item title is updated with `brew info` output
-//    func testUpdateInfo() {
-//        delegate.stdout = """
-//        231 kegs, 197,732 files, 5.1GB
-//        """
-//
-//        // Load MainMenu from xib
-//        var objects: NSArray?
-//        Bundle.main.loadNibNamed("MainMenu", owner: self, topLevelObjects: &objects)
-//        delegate.statusMenu = objects![0] as? NSMenu
-//
-//        // Brew info is set as title
-//        delegate.update_info()
-//        
-//        // Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: file
-//        let item = delegate.statusMenu.item(withTag: 3)
-//
-//        XCTAssert(item?.title == delegate.stdout)
-//    }
+    /// Info status item title is updated with `brew info` output
+    func testUpdateInfo() {
+        delegate.stdout = """
+        231 kegs, 197,732 files, 5.1GB
+        """
+
+        // Brew info is set as title
+        delegate.update_info()
+
+        // Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: file
+        let item = delegate.statusMenu.item(withTag: 3)
+
+        XCTAssert(item?.title == delegate.stdout)
+    }
+    
+    /// TODO ["info", "--json", "--installed"]
+    func testCheckOutdated() {
+    }
+
+
+
 }

--- a/BrewletTests/BrewletTests.swift
+++ b/BrewletTests/BrewletTests.swift
@@ -10,9 +10,6 @@ import XCTest
 
 @testable import Brewlet
 
-
-
-
 class BrewletTests: XCTestCase {
     
     // Create placeholder of application delegate to be set in `setUp`
@@ -24,7 +21,7 @@ class BrewletTests: XCTestCase {
         // allow unit tests to overwrite the stdout of the `run_command` closure
         var stdout: String = ""
         
-        /// `run_command` where `brew` is  not invoked
+        /// Modified to not run `brew` subprocess, and to use `stdout` property in closure
         override func run_command(
             arguments: [String],
             fileRedirect: FileHandle? = nil,
@@ -34,10 +31,14 @@ class BrewletTests: XCTestCase {
             outputHandler(Process(), self.stdout.data(using: .utf8)!)
         }
         
+        /// Disable notifications in tests
+        override func sendNotification(title: String, body: String, timeInterval: TimeInterval = 1) {
+            // pass
+        }
+        
     }
     
     override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
         super.setUp()
         delegate = StatelessAppDelegate()
         
@@ -60,70 +61,37 @@ class BrewletTests: XCTestCase {
     }
     
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
         delegate = nil
     }
     
-    /// Date is formatted appropriately
-    func testFormatDate() {
-        let d = Date(timeIntervalSinceReferenceDate: 410220000)
-        let f = delegate.formatDate(date: d)
-        XCTAssert(f == "Dec 31, 2013 at 5:00 PM")
+    func testSetupTimers() {
+        XCTAssertNil(delegate.timer)
+        delegate.setupTimers()
+        XCTAssertNotNil(delegate.timer)
+        XCTAssertTrue(delegate.timer!.isValid)
     }
     
-    /// Icon cycles through images when timer is fired
-    func testAnimateIconImages() {
-        let animateTimer = delegate.animateIcon()
+    func testUpdateUpgrade() {
+        delegate.update_upgrade(sender: nil)
         
-        // Status button image name initial value
-        XCTAssert(delegate.statusItem.button?.image?.name() == "BrewletIcon-Black")
-        
-        // Trigger the timer 7 times, the status icon name will increment from "Brewlet-Filled-0" to "Brewlet-Filled-6"
-        for n in 0...6 {
-            animateTimer.fire()
-            let statusImageName = (delegate.statusItem.button?.image?.name())!
-            NSLog("Status Image: \(statusImageName)")
-            XCTAssert("Brewlet-Filled-\(n)" == statusImageName)
-        }
+        // Last updated timestamp is set
+        let expectedStatus = "Brewlet. Last updated \(delegate.formatDate())"
+        XCTAssertEqual(expectedStatus, delegate.statusItem.button?.toolTip)
     }
     
-    /// User defaults are updated to desired interval value
-    func testUpdateIntervalChanges() {
-        delegate.updateIntervalChanged(newInterval: 3000)
-        let v0 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
-        XCTAssert(v0 == 3000)
-        
-        delegate.updateIntervalChanged(newInterval: 3600)
-        let v1 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
-        XCTAssert(v1 == 3600)
-    }
-    
-    /// Toggle share analytics in preferences - `brew` command is not invoked as  delegate method `run_command` has been overriden
-    func testShareAnalyticsChanged() {
-        delegate.shareAnalyticsChanged(newState: .on)
-        let v0 = delegate.userDefaults.bool(forKey: "shareAnalytics")
-        XCTAssert(v0 == true)
-        
-        delegate.shareAnalyticsChanged(newState: .off)
-        let v1 = delegate.userDefaults.bool(forKey: "shareAnalytics")
-        XCTAssert(v1 == false)
-    }
-    
-    /// `shareAnalytics` user default is toggled betweetn true and false
     func testToggleAnalytics() {
         delegate.toggle_analytics(turnOn: true)
         let s1 = delegate.userDefaults.bool(forKey: "shareAnalytics")
         NSLog("shareAnalytics: %d", s1)
-        XCTAssert(s1 == true)
+        XCTAssertTrue(s1)
         
         delegate.toggle_analytics(turnOn: false)
         let s2 = delegate.userDefaults.bool(forKey: "shareAnalytics")
         NSLog("shareAnalytics: %d", s2)
-        XCTAssert(s2 == false)
+        XCTAssertFalse(s2)
     }
     
-    /// `brew list -1` contents are written to `brew-packages.txt`
     func testExportList() {
         
         // re-instantiatiate delegate with mocked stdout
@@ -136,6 +104,7 @@ class BrewletTests: XCTestCase {
             )[0].appendingPathComponent("brew-packages.txt")
         NSLog("Reading from file: \(file)")
         do {
+            // `brew list -1` contents are written to `brew-packages.txt`
             let contents = try String(contentsOf: file, encoding: .utf8)
             XCTAssert(contents == "fzf\nfzf")
         } catch {
@@ -143,7 +112,6 @@ class BrewletTests: XCTestCase {
         }
     }
     
-    /// userDefault `shareAnalytics` is set to `brew analytics state`
     func testUpdateAnalytics() {
         delegate.stdout = """
         Analytics are enabled.
@@ -159,25 +127,73 @@ class BrewletTests: XCTestCase {
         XCTAssert(delegate.userDefaults.bool(forKey: "shareAnalytics") == false)
     }
     
-    /// Info status item title is updated with `brew info` output
+    func testCheckOutdated() {
+        // TODO
+    }
+    
+    func testFillPackageMenu() {
+        // TODO
+    }
+    
+    func testUpgradePackage() {
+        // TODO
+    }
+    
     func testUpdateInfo() {
         delegate.stdout = """
         231 kegs, 197,732 files, 5.1GB
         """
-
-        // Brew info is set as title
         delegate.update_info()
-
-        // Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: file
         let item = delegate.statusMenu.item(withTag: 3)
-
         XCTAssert(item?.title == delegate.stdout)
     }
-    
-    /// TODO ["info", "--json", "--installed"]
-    func testCheckOutdated() {
+        
+    func testAnimateIcon() {
+        let animateTimer = delegate.animateIcon()
+        
+        // Status button image name initial value
+        XCTAssert(delegate.statusItem.button?.image?.name() == "BrewletIcon-Black")
+        
+        // Trigger the timer 7 times, the status icon name will increment from "Brewlet-Filled-0" to "Brewlet-Filled-6"
+        for n in 0...6 {
+            animateTimer.fire()
+            let statusImageName = (delegate.statusItem.button?.image?.name())!
+            NSLog("Status Image: \(statusImageName)")
+            XCTAssert("Brewlet-Filled-\(n)" == statusImageName)
+        }
     }
-
-
-
+    
+    func testGetTemporaryFile() {
+        // TODO
+    }
+    
+    func testFormatDate() {
+        let d = Date(timeIntervalSinceReferenceDate: 410220000)
+        let f = delegate.formatDate(date: d)
+        XCTAssert(f == "Dec 31, 2013 at 5:00 PM")
+    }
+    
+    func testIncludeDependenciesChanged() {
+        // TODO
+    }
+    
+    func testShareAnalyticsChanged() {
+        delegate.shareAnalyticsChanged(newState: .on)
+        let v0 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+        XCTAssert(v0 == true)
+        
+        delegate.shareAnalyticsChanged(newState: .off)
+        let v1 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+        XCTAssert(v1 == false)
+    }
+    
+    func testUpdateIntervalChanges() {
+        delegate.updateIntervalChanged(newInterval: 3000)
+        let v0 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
+        XCTAssert(v0 == 3000)
+        
+        delegate.updateIntervalChanged(newInterval: 3600)
+        let v1 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
+        XCTAssert(v1 == 3600)
+    }
 }

--- a/BrewletTests/BrewletTests.swift
+++ b/BrewletTests/BrewletTests.swift
@@ -6,11 +6,23 @@
 //  Copyright © 2020 zzada. All rights reserved.
 //
 
+// TODO - mock "run_command"
+
 import XCTest
 
 @testable import Brewlet
 
 class BrewletTests: XCTestCase {
+    
+    /// App delegate where functions with side-effects have been removed
+    class StatelessAppDelegate : AppDelegate {
+        
+        /// `run_command` where `brew` is not actually invoked
+        override func run_command(arguments: [String], fileRedirect: FileHandle? = nil, outputHandler: @escaping (Process, Data) -> Void) {
+            NSLog("overridden `run_command`")
+        }
+    
+    }
 
     // Create placeholder of application delegate
     var delegate: AppDelegate!
@@ -18,7 +30,7 @@ class BrewletTests: XCTestCase {
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         super.setUp()
-        delegate = NSApplication.shared.delegate as! AppDelegate
+        delegate = StatelessAppDelegate() as! AppDelegate
         
         // Re-initialize defaults instead of triggering `applicationDidFinishLaunching`
         delegate.statusItem.button?.toolTip = "Brewlet"
@@ -62,6 +74,19 @@ class BrewletTests: XCTestCase {
         let v1 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
         XCTAssert(v1 == 3600)
     }
+    
+    // NOTE: this does not work, as the overriden `run_command` will not trigger the
+    // self.userDefaults.set(turnOn, forKey: "shareAnalytics") in `toggle_analytics`
+//    /// Toggle share analytics in preferences - `brew` command is not invoked as  delegate method `run_command` has been overriden
+//    func testShareAnalyticsChanged() {
+//        delegate.shareAnalyticsChanged(newState: .on)
+//        let v0 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+//        XCTAssert(v0 == true)
+//
+//        delegate.shareAnalyticsChanged(newState: .off)
+//        let v1 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+//        XCTAssert(v1 == false)
+//    }
 
 //    func testToggleAnalytics() {
 //

--- a/BrewletTests/BrewletTests.swift
+++ b/BrewletTests/BrewletTests.swift
@@ -1,0 +1,51 @@
+//
+//  BrewletTests.swift
+//  BrewletTests
+//
+//  Created by Colton Padden on 5/17/20.
+//  Copyright © 2020 zzada. All rights reserved.
+//
+
+import XCTest
+
+@testable import Brewlet
+
+class BrewletTests: XCTestCase {
+
+    // Create placeholder of application delegate
+    var delegate: AppDelegate!
+    
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        super.setUp()
+        delegate = NSApplication.shared.delegate as! AppDelegate
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+        delegate = nil
+    }
+    
+    func testFormatDate() {
+        let d = Date(timeIntervalSinceReferenceDate: 410220000)
+        let f = delegate.formatDate(date: d)
+        XCTAssert(f == "Dec 31, 2013 at 5:00 PM")
+    }
+
+//    func testToggleAnalytics() {
+//
+//        // NOTE: this will actually set the analytics setting for homebrew, we should figure out how
+//        // to mock this functionality.
+//
+//        delegate.toggle_analytics(turnOn: true)
+//        let s1 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+//        NSLog("shareAnalytics: %d", s1)
+//        XCTAssert(s1 == true)
+//
+//        delegate.toggle_analytics(turnOn: false)
+//        let s2 = delegate.userDefaults.bool(forKey: "shareAnalytics")
+//        NSLog("shareAnalytics: %d", s2)
+//        XCTAssert(s2 == false)
+//    }
+}

--- a/BrewletTests/BrewletTests.swift
+++ b/BrewletTests/BrewletTests.swift
@@ -51,6 +51,17 @@ class BrewletTests: XCTestCase {
             XCTAssert("Brewlet-Filled-\(n)" == statusImageName)
         }
     }
+    
+    /// Ensure user defaults is updated to desired interval value
+    func testUpdateIntervalChanges() {
+        delegate.updateIntervalChanged(newInterval: 3000)
+        let v0 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
+        XCTAssert(v0 == 3000)
+        
+        delegate.updateIntervalChanged(newInterval: 3600)
+        let v1 = delegate.userDefaults.value(forKey: "updateInterval") as! Int
+        XCTAssert(v1 == 3600)
+    }
 
 //    func testToggleAnalytics() {
 //

--- a/BrewletTests/Info.plist
+++ b/BrewletTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
I'm still very new to programming in Swift, so any help on this would be greatly appreciated. So far I've only tested the most basic functions in the AppDelegate. More sophisticated tests will be requried for methods with side-effects.

- [x] Determine how to mock methods with side-effects (ie. calls to the `brew` utility)
- [x] Determine how to mock tests that alter state (ie. changes to preferences)
- [ ] Integrate with coveralls - https://coveralls.io/
- [ ] Mock userDefaults so that they are not overwritten

_Edit:_ mocking may not be necessary in Swift, as we can extend the AppDelegate and override functions like `run_command` so that the sub process is not triggered (See: https://stackoverflow.com/a/24916681)