### PR TITLE
Make Default StatusImage a Template

### DIFF
--- a/Brewlet/AppDelegate.swift
+++ b/Brewlet/AppDelegate.swift
@@ -39,6 +39,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, PreferencesDelegate {
         statusItem.menu = statusMenu
         statusItem.button?.toolTip = "Brewlet"
         statusItem.button?.image = NSImage(named: "BrewletIcon-Black")
+        statusItem.button?.image?.isTemplate = true
 
         // Set up preferences window
         preferencesWindow = PreferencesController()


### PR DESCRIPTION
Setting `isTemplate` to true we ensure that the icon is used as a
template and the system will handle it appropriately

Resolves #9.