### PR TITLE
Fix crash: run brew command output handlers on the main thread

### DIFF
--- a/Brewlet/AppDelegate.swift
+++ b/Brewlet/AppDelegate.swift
@@ -552,8 +552,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, PreferencesDelegate {
                 os_log("Standard out type is unknown.", type: .error)
             }
             
-            // Handle the output of the command
-            outputHandler(process, allData)
+            // Handle the output of the command on the main thread.
+            //
+            // `Process.terminationHandler` is invoked on an arbitrary background
+            // thread. Every `outputHandler` passed to `run_command` mutates AppKit
+            // UI (NSMenuItem titles, status-bar image, submenu items, …), which is
+            // only safe on the main thread. Doing it off-main intermittently aborts
+            // the app with an uncaught AppKit/AutoLayout exception — most reliably
+            // when a brew task finishes while the status-bar menu is open, because
+            // changing a menu item's title then forces a live relayout of the open
+            // popup window from the wrong thread.
+            //
+            // Dispatching here (the single choke point) rather than at each call
+            // site guarantees all handlers run on the main thread.
+            DispatchQueue.main.async {
+                outputHandler(process, allData)
+            }
         }
         
         // Run it asynch


### PR DESCRIPTION
## Problem

Brewlet crashes (SIGABRT, `Abort trap: 6`) when clicking the tray icon while a background `brew` task finishes. The crash is an uncaught AppKit/AutoLayout exception thrown on a **background thread**:

objc_exception_throw
-[NSISEngine optimize]                              ← AutoLayout engine throws
-[NSPopupMenuWindow setFrame:display:animate:]
-[NSMenuItem setTitle:]                             ← title set off the main thread
__45-[NSConcreteTask launchWithDictionary:error:]_block_invoke_2   ← brew task finished

Meanwhile the main thread is inside the status-bar menu tracking loop, blocked on `-[NSViewHierarchyLock _lockForWriting:]`.

## Root cause

`Process.terminationHandler` runs on an arbitrary background thread. Every `outputHandler` passed to `run_command` mutates AppKit UI. When a `brew` task finishes while the menu is open, setting a menu item's title forces a live relayout of the open popup window from the wrong thread, and the AutoLayout engine throws. The existing `DispatchQueue.main.async` blocks only guard the icon *image*, not the *titles* that trigger the relayout. This became reliably fatal on recent macOS, which is stricter about off-main-thread UI mutation.

## Fix

Dispatch `outputHandler` to the main queue at the single choke point inside `run_command`, so all 11 completion handlers run on the main thread. Using `async` (not `sync`) avoids deadlocking against the main thread while it holds the view-hierarchy lock during menu tracking.

## Testing

Builds cleanly (`xcodebuild`, Xcode 26.6). Verified against the reported crash signature from the released 1.7.4 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)